### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/t/bench-results/bench-results.py
+++ b/t/bench-results/bench-results.py
@@ -20,4 +20,4 @@ for i in logs:
 	data.append([patches, hours])
 data.sort(cmp=cmp_data)
 for i in data:
-	print "%s %s" % (i[0], i[1])
+	print "{0!s} {1!s}".format(i[0], i[1])


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:darcs-fast-export?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:darcs-fast-export?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
